### PR TITLE
renderErrorsAsMap added. Similar to renderErrors but instead of a domain class, it uses a list of maps.

### DIFF
--- a/ZkuiGrailsPlugin.groovy
+++ b/ZkuiGrailsPlugin.groovy
@@ -10,6 +10,7 @@ import org.grails.plugins.zkui.artefacts.composer.ComposerArtefactHandler
 import org.grails.plugins.zkui.artefacts.vm.ViewModelArtefactHandler
 import org.grails.plugins.zkui.metaclass.RedirectDynamicMethod
 import org.grails.plugins.zkui.util.UriUtil
+import org.grails.plugins.zkui.util.ComponentErrorRendererUtil
 import org.zkoss.zk.ui.Component
 import org.zkoss.zk.ui.Executions
 import org.zkoss.zk.ui.Page
@@ -235,21 +236,10 @@ The different is it more likely to use the Grails' infrastructures such as gsp, 
             }
         }
 
+      ComponentErrorRendererUtil errorRendererUtil = new ComponentErrorRendererUtil()
 
-      /**
-      Allow the use of renderErrors but for non-domain classes.
-      **/
-      org.zkoss.zk.ui.Component.metaClass.renderErrorsAsMap = {Map args->
-         for(_error in args.bean.errors){
-            def name = _error.field
+      errorRendererUtil.addRenderMapAsErrors()
 
-            def selectedComponentList = delegate.select("[name='${name}']")
-            if(selectedComponentList.size() > 0 && selectedComponentList[0] instanceof InputElement){
-               selectedComponentList[0].setErrorMessage(_error.error)
-            }
-         }
-
-      }
         org.zkoss.zk.ui.Session.metaClass.getAt = { String name ->
             delegate.getAttribute(name)
         }

--- a/ZkuiGrailsPlugin.groovy
+++ b/ZkuiGrailsPlugin.groovy
@@ -235,6 +235,21 @@ The different is it more likely to use the Grails' infrastructures such as gsp, 
             }
         }
 
+
+      /**
+      Allow the user of renderErrors but for non-domain classes.
+      **/
+      org.zkoss.zk.ui.Component.metaClass.renderErrorsAsMap = {Map args->
+         for(_error in args.bean.errors){
+            def name = _error.field
+
+            def selectedComponentList = delegate.select("[name='${name}']")
+            if(selectedComponentList.size() > 0 && selectedComponentList[0] instanceof InputElement){
+               selectedComponentList[0].setErrorMessage(_error.error)
+            }
+         }
+
+      }
         org.zkoss.zk.ui.Session.metaClass.getAt = { String name ->
             delegate.getAttribute(name)
         }

--- a/ZkuiGrailsPlugin.groovy
+++ b/ZkuiGrailsPlugin.groovy
@@ -237,7 +237,7 @@ The different is it more likely to use the Grails' infrastructures such as gsp, 
 
 
       /**
-      Allow the user of renderErrors but for non-domain classes.
+      Allow the use of renderErrors but for non-domain classes.
       **/
       org.zkoss.zk.ui.Component.metaClass.renderErrorsAsMap = {Map args->
          for(_error in args.bean.errors){

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Thu May 10 09:44:42 CST 2012
+#Tue May 15 08:48:49 CST 2012
 app.grails.version=2.0.3
 app.name=zkui
 plugins.rest-client-builder=1.0.2

--- a/src/groovy/org/grails/plugins/zkui/util/ComponentErrorRendererUtil.groovy
+++ b/src/groovy/org/grails/plugins/zkui/util/ComponentErrorRendererUtil.groovy
@@ -1,0 +1,21 @@
+package org.grails.plugins.zkui.util
+
+import org.zkoss.zul.impl.InputElement
+import org.zkoss.zk.ui.Component
+
+class ComponentErrorRendererUtil{
+   
+   public void addRenderMapAsErrors(){
+      org.zkoss.zk.ui.Component.metaClass.renderMapAsErrors = {Map args->
+         for(_error in args.bean.errors){
+            def name = _error.field
+
+            def selectedComponentList = delegate.select("[name='${name}']")
+            if(selectedComponentList.size() > 0 && selectedComponentList[0] instanceof InputElement){
+               selectedComponentList[0].setErrorMessage(_error.error)
+            }
+         }
+
+      }
+   }
+}

--- a/test/unit/org/grails/plugins/zkui/util/ComponentErrorRendererUtilTests.groovy
+++ b/test/unit/org/grails/plugins/zkui/util/ComponentErrorRendererUtilTests.groovy
@@ -1,0 +1,38 @@
+package org.grails.plugins.zkui.util
+
+import static org.junit.Assert.*
+import org.zkoss.zul.impl.InputElement
+import org.zkoss.zk.ui.Component
+import org.zkoss.zul.Textbox
+import org.zkoss.zul.Window
+import grails.test.*
+
+class ComponentErrorRendererUtilTests extends ComposerUnitTestCase{
+
+   Window component
+   Textbox txt1
+
+   @Before
+   void setUp(){
+      Window.metaClass.select = { [txt1] }
+      component = new Window()
+      txt1 = new Textbox()
+      txt1.setName('name')
+      component.appendChild(txt1)
+   }
+
+   @Test
+   void should_add_renderMapAsErrors_to_InputElement(){
+      ComponentErrorRendererUtil util = new ComponentErrorRendererUtil()
+      util.addRenderMapAsErrors()
+
+      def params = [errors:[[field: 'name', error: 'Name can not be empty']]]
+
+      component.renderMapAsErrors(bean: params)
+
+      assertEquals 'Name can not be empty', txt1.getErrorMessage()
+
+
+   }
+
+}


### PR DESCRIPTION
In a Composer, it is now possible to do:
self.renderErrorsAsMap(bean:map)
This does the same as renderErrors, but instead of taking domain class,
it takes a list of maps. The map is structured as follows:
[field: field, error: error].
This is useful whenever one is using an api that returns json , or a
map.
