### PR TITLE
Enable use of converter spring beans

### DIFF
--- a/src/groovy/org/grails/plugins/zkui/AbstractTagLib.groovy
+++ b/src/groovy/org/grails/plugins/zkui/AbstractTagLib.groovy
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse
 
 import org.zkoss.zk.ui.*
 import org.zkoss.zk.ui.sys.*
+import org.zkoss.zkplus.spring.DelegatingVariableResolver
 
 abstract class AbstractTagLib implements ApplicationContextAware {
     ApplicationContext applicationContext
@@ -113,6 +114,7 @@ abstract class AbstractTagLib implements ApplicationContextAware {
             if (zkPageStyle) {
                 page.setStyle(zkPageStyle)
             }
+            page.addVariableResolver(new DelegatingVariableResolver())
             final Execution exec = new ExecutionImpl(servletContext, request, response, desktop, page)
             final boolean cacheable = exec.getDesktop().getDevice().isCacheable()
             if (!cacheable) {


### PR DESCRIPTION
Hi Groovyquan!

In order to use the feature [Converter as a Singleton Bean](http://books.zkoss.org/wiki/Small_Talks/2012/February/MVVM_in_ZK6:_Work_with_Spring#Converter_as_a_Singleton_Bean) is needed add DelegatingVariableResolver in page.
In my opinion, this feature can stay always enabled in an grails application.
This change has this objective.

I hope this can help.

Best regards,

Thiago Lacerda
