### PR TITLE
Update ZkGrailsTemplateGenerator.groovy

### DIFF
--- a/src/groovy/org/grails/plugins/zkui/scaffolding/ZkGrailsTemplateGenerator.groovy
+++ b/src/groovy/org/grails/plugins/zkui/scaffolding/ZkGrailsTemplateGenerator.groovy
@@ -351,4 +351,13 @@ class ZkGrailsTemplateGenerator implements GrailsTemplateGenerator, ResourceLoad
     void generateTest(GrailsDomainClass domainClass, String destDir) throws IOException {
         //do nothing
     }
+    
+	void generateRestfulController(GrailsDomainClass domainClass, String destDir){
+		//do nothing
+	}
+	
+	void generateRestfulTest(GrailsDomainClass domainClass, String destDir){
+		//do nothing
+	}
+
 }


### PR DESCRIPTION
Added lines 355-361 (implemented GrailsTemplateGenerator.java methods) for grails 2.4.3.
